### PR TITLE
Add arguments to specify initial tile offset

### DIFF
--- a/pyfeatures/app/calc.py
+++ b/pyfeatures/app/calc.py
@@ -65,6 +65,8 @@ def run(logger, args, extra_argv=None):
                     'h': args.height,
                     'dx': args.delta_x,
                     'dy': args.delta_y,
+                    'ox': args.offset_x,
+                    'oy': args.offset_y,
                 }
                 for fv in calc_features(pixels, p.name, **kw):
                     out_rec = to_avro(fv)
@@ -90,5 +92,9 @@ def add_parser(subparsers):
                         help="horizontal distance between consecutive tiles")
     parser.add_argument("-y", "--delta-y", type=int, metavar="INT",
                         help="vertical distance between consecutive tiles")
+    parser.add_argument("--offset-x", type=int, metavar="INT",
+                        help="horizontal offset of first tile (default 0)")
+    parser.add_argument("--offset-y", type=int, metavar="INT",
+                        help="vertical offset of first tile (default 0)")
     parser.set_defaults(func=run)
     return parser

--- a/pyfeatures/app/tiles.py
+++ b/pyfeatures/app/tiles.py
@@ -62,7 +62,8 @@ def run(logger, args, extra_argv=None):
     my = max(1, .05 * args.iH)
     ax.axis([-mx, args.iW + mx, -my, args.iH + my])
     for i, j, tile in gen_tiles(img_array, w=args.W, h=args.H,
-                                dx=args.x, dy=args.y):
+                                dx=args.x, dy=args.y,
+                                ox=args.offset_x, oy=args.offset_y):
         h, w = tile.shape
         ax.add_patch(patches.Rectangle((j, i), w, h, alpha=TILE_ALPHA))
         logger.debug("%r", (j, i, w, h))

--- a/pyfeatures/app/tiles.py
+++ b/pyfeatures/app/tiles.py
@@ -43,6 +43,10 @@ def add_parser(subparsers):
     parser.add_argument("-H", type=int, metavar="INT", help="tile height")
     parser.add_argument("-x", type=int, metavar="INT", help="tile x-distance")
     parser.add_argument("-y", type=int, metavar="INT", help="tile y-distance")
+    parser.add_argument("--offset-x", type=int, metavar="INT",
+                        help="tile initial x-offset")
+    parser.add_argument("--offset-y", type=int, metavar="INT",
+                        help="tile initial y-offset")
     parser.add_argument('-o', '--out-fn', metavar='FILE', default="tiles.png",
                         help="output file (extension = img format)")
     parser.set_defaults(func=run)

--- a/pyfeatures/feature_calc.py
+++ b/pyfeatures/feature_calc.py
@@ -56,6 +56,7 @@ def gen_tiles(img_array, w=None, h=None, dx=None, dy=None, ox=None, oy=None):
         raise ValueError("smallest tile size is 1 x 1")
     if dx < 1 or dy < 1:
         raise ValueError("smallest distance between tiles is 1")
+    # min(...): a maximum of one partial tile in that dimension
     for i in xrange(oy, min(H, H - h + dy), dy):
         for j in xrange(ox, min(W, W - w + dx), dx):
             yield i, j, img_array[i: i + h, j: j + w]

--- a/pyfeatures/feature_calc.py
+++ b/pyfeatures/feature_calc.py
@@ -36,7 +36,7 @@ def get_image_matrix(img_array):
     return image_matrix
 
 
-def gen_tiles(img_array, w=None, h=None, dx=None, dy=None):
+def gen_tiles(img_array, w=None, h=None, dx=None, dy=None, ox=None, oy=None):
     if len(img_array.shape) != 2:
         raise ValueError("array must be two-dimensional")
     H, W = img_array.shape
@@ -48,20 +48,25 @@ def gen_tiles(img_array, w=None, h=None, dx=None, dy=None):
         dx = w
     if dy is None:
         dy = h
+    if ox is None:
+        ox = 0
+    if oy is None:
+        oy = 0
     if w < 1 or h < 1:
         raise ValueError("smallest tile size is 1 x 1")
     if dx < 1 or dy < 1:
         raise ValueError("smallest distance between tiles is 1")
-    for i in xrange(0, min(H, H - h + dy), dy):
-        for j in xrange(0, min(W, W - w + dx), dx):
+    for i in xrange(oy, min(H, H - h + dy), dy):
+        for j in xrange(ox, min(W, W - w + dx), dx):
             yield i, j, img_array[i: i + h, j: j + w]
 
 
 def calc_features(img_array, tag, long=False, w=None, h=None,
-                  dx=None, dy=None):
+                  dx=None, dy=None, ox=None, oy=None):
     if len(img_array.shape) != 2:
         raise ValueError("array must be two-dimensional")
-    for i, j, tile in gen_tiles(img_array, w=w, h=h, dx=dx, dy=dy):
+    for i, j, tile in gen_tiles(
+            img_array, w=w, h=h, dx=dx, dy=dy, ox=ox, oy=oy):
         signatures = FeatureVector(basename=tag, long=long)
         signatures.original_px_plane = get_image_matrix(tile)
         signatures.GenerateFeatures(write_to_disk=False)

--- a/test/test_feature_calc.py
+++ b/test/test_feature_calc.py
@@ -92,6 +92,11 @@ class TestGenTiles(unittest.TestCase):
              [(0, 3, 0, 8)]),
             ({'w': None, 'h': 3, 'dx': None, 'dy': 100},
              [(0, 3, 0, 8)]),
+            # --
+            ({'w': None, 'h': 3, 'dx': None, 'dy': 1, 'ox': None, 'oy': 1},
+             [(1, 4, 0, 8), (2, 5, 0, 8), (3, 6, 0, 8)]),
+            ({'w': 6, 'h': 4, 'dx': W, 'dy': H, 'ox': 1, 'oy': 1},
+             [(1, 5, 1, 7)]),
         ]
 
     def runTest(self):


### PR DESCRIPTION
Currently tiles are generated starting from `(0, 0)`. This adds two arguments to allow an initial offset `(ox, oy)` to be specified.