### PR TITLE
Add args for manipulating avro name matches against omero

### DIFF
--- a/scripts/omero/omerofeatures.py
+++ b/scripts/omero/omerofeatures.py
@@ -60,13 +60,13 @@ def parse_args(args):
         'mapping', help='Mapping of OMERO IDs to avro records (tsv)')
     parser.add_argument(
         '--re-pattern', default='.*', help=(
-            'Match a substring of the avros name against the mapping file, '
+            'Match a substring of the avro name against the mapping file, '
             'e.g. "^[A-Za-z0-9]" to ignore everything after an '
             'alpha-numeric prefix.'))
     parser.add_argument(
         '--re-match', help=(
             'Match a replacement pattern based on --re-pattern. '
-            'E.g. "(\1)-(\2)" to match two pattern groups joined with "-". '
+            'E.g. "\1-\2" to match two pattern groups joined with "-". '
             'Default is to match the whole pattern.'))
     parser.add_argument(
         'output', help='Output OMERO.features file (append if exists)')
@@ -185,7 +185,6 @@ def convert_avro(
                     rname = re.sub(repattern, rematch, r['name'])
                 else:
                     rname = re.search(repattern, r['name']).group(0)
-                print repattern, rematch, r['name'], rname
                 oid = omero_ids[c.name][rname]
                 c.values.append(oid)
             else:

--- a/scripts/omero/omerofeatures.py
+++ b/scripts/omero/omerofeatures.py
@@ -206,7 +206,7 @@ def main(argv):
             init_needed = not os.path.exists(fileout)
             cols = convert_avro(
                 f, omero_ids, id_fields, expected_features,
-                args.re_pattern,args.re_match)
+                args.re_pattern, args.re_match)
             t = omero.tables.HDFLIST.getOrCreate(fileout)
             if init_needed:
                 t.initialize(cols)


### PR DESCRIPTION
If the OMERO plate names output by `map_series.py` are different from the name inside the avro feature files then `omerofeatures.py` will fail. This PR adds two regular-expression arguments to transform the name in the avro file to that expected in the mapping file.

I originally tried to do this by modifying `map_series.py` to read the screen file, but the filenames in the screen file are different from the avro feature file names.